### PR TITLE
Refinements for exporting shapefiles 

### DIFF
--- a/landmapper/app/static/landmapper/css/report.css
+++ b/landmapper/app/static/landmapper/css/report.css
@@ -34,7 +34,10 @@ p {
     margin: 4px 0;
   }
 
-  .action-wrap button:disabled {
+  .action-wrap .disabled,
+  .action-wrap :disabled {
+    background: rgba(60, 60, 60, 0.2);
+    opacity: 0.5;
     pointer-events: none;
   }
 

--- a/landmapper/app/static/landmapper/js/report.js
+++ b/landmapper/app/static/landmapper/js/report.js
@@ -36,6 +36,7 @@ if (copyToAccountBtn) {
    */
   function exportLayerHandler() {
     const propertyPk = this.getAttribute('data-property-id');
+    const propertyName = this.getAttribute('data-property-name');
     const exportLayerButton = this;
 
     // Disable the button to prevent multiple clicks
@@ -53,7 +54,7 @@ if (copyToAccountBtn) {
         const a = document.createElement('a');
         a.style.display = 'none';
         a.href = url;
-        a.download = `${propertyPk}.zip`;
+        a.download = `${propertyName}.zip`;
         document.body.appendChild(a);
         a.click();
         window.URL.revokeObjectURL(url);

--- a/landmapper/app/templates/landmapper/report/report-overview.html
+++ b/landmapper/app/templates/landmapper/report/report-overview.html
@@ -50,16 +50,15 @@
                     
                     {% if user.is_authenticated and property.user_id == user_id %}
                         
-                        <!-- Export Layer Button -->
-                        <button id="export-layer-button" class="btn btn-primary btn-action d-print-none" data-property-id="{{ property.pk }}" data-property-name="{{ property_name }}" aria-label="Dowmload Shape file of Property">
+                        <!-- Export SHP Button -->
+                        <button id="export-layer-button" class="btn btn-primary btn-action d-print-none" data-property-id="{{ property.pk }}" data-property-name="{{ property_name }}" aria-label="Dowmload Shape file of Property" title="Download shape file of property">
                             <img src="{% static 'landmapper/img/icon/icon-shp.svg' %}" class="icon-shp icon" alt="Shape file icon" />
-                            {% comment %} <span>SHP</span> {% endcomment %}
                         </button>
                     
                     {% elif user.is_authenticated and property.user_id != user_id %}
                         
-                        <!-- Export Layer Button -->
-                        <button disabled id="export-layer-button" class="btn btn-primary btn-action d-print-none disabled" aria-label="Dowmload Shape file of Property">
+                        <!-- Export SHP Button -->
+                        <button disabled id="export-layer-button" class="btn btn-primary btn-action d-print-none disabled" aria-label="Dowmload Shape file of Property" title="Copy to your properties to export shape file">
                             <img src="{% static 'landmapper/img/icon/icon-shp.svg' %}" class="icon-shp icon" alt="Shape file icon" />
                         </button>
 
@@ -68,10 +67,11 @@
                     {% else %}
 
                         <!-- Export Layer Button -->
-                        <button disabled id="export-layer-button" class="btn btn-primary btn-action d-print-none disabled" aria-label="Dowmload Shape file of Property">
+                        <button disabled id="export-layer-button" class="btn btn-primary btn-action d-print-none disabled" aria-label="Dowmload Shape file of Property" title="login to download shape file of property">
                             <img src="{% static 'landmapper/img/icon/icon-shp.svg' %}" class="icon-shp icon" alt="Shape file icon" />
-                            {% comment %} <span>SHP</span> {% endcomment %}
                         </button>
+
+                        <a href="/auth/login/?next=/landmapper/report/{{ property_id }}" class="link-primary" target="_blank"><strong>Login to download</strong></a>
 
                     {% endif %}
 
@@ -94,7 +94,6 @@
 
                         <a href="" class="btn btn-primary btn-action d-print-none disabled" target="_blank" aria-label="Download PDF report">
                             <img src="{% static 'landmapper/img/icon/icon-pdf.svg' %}" class="icon-download icon" alt="PDF icon" />
-                            {% comment %} <span>PDF</span> {% endcomment %}
                         </a>
                     
                         <a href="/auth/login/?next=/landmapper/report/{{ property_id }}" class="link-primary" target="_blank"><strong>Login to download</strong></a>

--- a/landmapper/app/templates/landmapper/report/report-overview.html
+++ b/landmapper/app/templates/landmapper/report/report-overview.html
@@ -51,7 +51,7 @@
                     {% if user.is_authenticated and property.user_id == user_id %}
                         
                         <!-- Export Layer Button -->
-                        <button id="export-layer-button" class="btn btn-primary btn-action d-print-none" data-property-id="{{ property.pk }}" aria-label="Dowmload Shape file of Property">
+                        <button id="export-layer-button" class="btn btn-primary btn-action d-print-none" data-property-id="{{ property.pk }}" data-property-name="{{ property_name }}" aria-label="Dowmload Shape file of Property">
                             <img src="{% static 'landmapper/img/icon/icon-shp.svg' %}" class="icon-shp icon" alt="Shape file icon" />
                             {% comment %} <span>SHP</span> {% endcomment %}
                         </button>

--- a/landmapper/app/views.py
+++ b/landmapper/app/views.py
@@ -771,7 +771,7 @@ def export_layer(request, property_pk):
     database_name = settings.DATABASES['default']['NAME']
     sanitized_name = re.sub(r'[^a-zA-Z0-9_-]', '_', property_record.name)
     filename = f"{sanitized_name}"
-    shpdir = os.path.join(settings.SHAPEFILE_EXPORT_DIR, property_pk)
+    shpdir = os.path.join(settings.SHAPEFILE_EXPORT_DIR, sanitized_name)
     os.makedirs(shpdir, exist_ok=True)
 
     try:


### PR DESCRIPTION
This pull request includes several changes to enhance the user experience and improve the functionality of the Landmapper application. The updates include modifications to the CSS, JavaScript, HTML templates, and a Python view function.

Enhancements to user experience and functionality:

* [`landmapper/app/static/landmapper/css/report.css`](diffhunk://#diff-f07dbd13b877f79d21ab116153dc568a4dea344e8a0439508b617ba358cf15a4L37-R40): Updated the `.action-wrap` class to handle both `.disabled` and `:disabled` states by changing the background and opacity, and disabling pointer events.

* [`landmapper/app/static/landmapper/js/report.js`](diffhunk://#diff-89e4d3b0ebe079249e04717830c6548108651e2a505a09d33b268777e4b63213R39): Added `data-property-name` attribute to the export layer button and used it for the download filename instead of `data-property-id`. [[1]](diffhunk://#diff-89e4d3b0ebe079249e04717830c6548108651e2a505a09d33b268777e4b63213R39) [[2]](diffhunk://#diff-89e4d3b0ebe079249e04717830c6548108651e2a505a09d33b268777e4b63213L56-R57)

* `landmapper/app/templates/landmapper/report/report-overview.html`: 
  - Added `data-property-name` attribute to the export layer button and updated the title for better accessibility.
  - Included a login link for users who are not authenticated, prompting them to log in to download the shape file. [[1]](diffhunk://#diff-1b4404305deb31d8673ba2aacdfb349475fc94f2e70547c61f00ff8742c20a96L53-R61) [[2]](diffhunk://#diff-1b4404305deb31d8673ba2aacdfb349475fc94f2e70547c61f00ff8742c20a96L71-R75) [[3]](diffhunk://#diff-1b4404305deb31d8673ba2aacdfb349475fc94f2e70547c61f00ff8742c20a96L97)

* [`landmapper/app/views.py`](diffhunk://#diff-04f9088863acf1fa652d16c0d65e277005e42090a75b4444888c2bb4dccd3e29L774-R774): Modified the `export_layer` view function to use the sanitized property name for the shapefile export directory instead of the property primary key.

